### PR TITLE
Use of comments in ARM templates is allowed

### DIFF
--- a/AzPolicyTest/fileContent.tests.ps1
+++ b/AzPolicyTest/fileContent.tests.ps1
@@ -27,6 +27,7 @@ Foreach ($file in $files)
 		Context "JSON Syntax Test" {
 			It 'Should be a valid JSON file' {
 				$fileContent = Get-Content -Path $file -Raw
+				$fileContent = $fileContent -replace '(?m)(?<=^([^"]|"[^"]*")*)//.*' -replace '(?ms)/\*.*?\*/'
 				ConvertFrom-Json -InputObject $fileContent -ErrorVariable parseError
 				$parseError | Should Be $Null
 			}


### PR DESCRIPTION
Nowadays it is allowed to use comments in ARM templates. But this will file parsing from Json. Added a code line to remove all comments from the ARM template content variable before parsing.